### PR TITLE
后端-实现微信端学生端所有接口

### DIFF
--- a/GenshinStart_backend/pom.xml
+++ b/GenshinStart_backend/pom.xml
@@ -130,6 +130,12 @@
             <version>7.2.25</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.9</version>
+        </dependency>
+
         <!-- hot debug -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/configuration/property/SystemConfig.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/configuration/property/SystemConfig.java
@@ -15,6 +15,7 @@ public class SystemConfig {
 
     private PasswordKeyConfig pwdKey;
     private List<String> securityIgnoreUrls;
+    private WxConfig wx;
     private QnConfig qn;
 
     /**
@@ -51,6 +52,24 @@ public class SystemConfig {
      */
     public void setSecurityIgnoreUrls(List<String> securityIgnoreUrls) {
         this.securityIgnoreUrls = securityIgnoreUrls;
+    }
+
+    /**
+     * Gets wx.
+     *
+     * @return the wx
+     */
+    public WxConfig getWx() {
+        return wx;
+    }
+
+    /**
+     * Sets wx.
+     *
+     * @param wx the wx
+     */
+    public void setWx(WxConfig wx) {
+        this.wx = wx;
     }
 
     /**

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/configuration/property/WxConfig.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/configuration/property/WxConfig.java
@@ -1,0 +1,93 @@
+package com.example.genshinstart_backend.configuration.property;
+
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * @version 1.1.0
+ * @description: The type Wx config.
+ * @author kodi
+ * @date 2024/7/11 11:30
+ */
+public class WxConfig {
+
+
+    private String appid;
+    private String secret;
+    private Duration tokenToLive;
+    private List<String> securityIgnoreUrls;
+
+    /**
+     * Gets appid.
+     *
+     * @return the appid
+     */
+    public String getAppid() {
+        return appid;
+    }
+
+    /**
+     * Sets appid.
+     *
+     * @param appid the appid
+     */
+    public void setAppid(String appid) {
+        this.appid = appid;
+    }
+
+    /**
+     * Gets secret.
+     *
+     * @return the secret
+     */
+    public String getSecret() {
+        return secret;
+    }
+
+    /**
+     * Sets secret.
+     *
+     * @param secret the secret
+     */
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+
+    /**
+     * Gets token to live.
+     *
+     * @return the token to live
+     */
+    public Duration getTokenToLive() {
+        return tokenToLive;
+    }
+
+    /**
+     * Sets token to live.
+     *
+     * @param tokenToLive the token to live
+     */
+    public void setTokenToLive(Duration tokenToLive) {
+        this.tokenToLive = tokenToLive;
+    }
+
+    /**
+     * Gets security ignore urls.
+     *
+     * @return the security ignore urls
+     */
+    public List<String> getSecurityIgnoreUrls() {
+        return securityIgnoreUrls;
+    }
+
+    /**
+     * Sets security ignore urls.
+     *
+     * @param securityIgnoreUrls the security ignore urls
+     */
+    public void setSecurityIgnoreUrls(List<String> securityIgnoreUrls) {
+        this.securityIgnoreUrls = securityIgnoreUrls;
+    }
+
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/configuration/spring/wx/TokenHandlerInterceptor.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/configuration/spring/wx/TokenHandlerInterceptor.java
@@ -1,0 +1,68 @@
+package com.example.genshinstart_backend.configuration.spring.wx;
+
+import com.example.genshinstart_backend.base.SystemCode;
+import com.example.genshinstart_backend.configuration.spring.security.RestUtil;
+import com.example.genshinstart_backend.context.WxContext;
+import com.example.genshinstart_backend.domain.User;
+import com.example.genshinstart_backend.domain.UserToken;
+import com.example.genshinstart_backend.service.UserService;
+import com.example.genshinstart_backend.service.UserTokenService;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Date;
+
+@Component
+public class TokenHandlerInterceptor implements HandlerInterceptor {
+
+    private final UserTokenService userTokenService;
+    private final UserService userService;
+    private final WxContext wxContext;
+
+    @Autowired
+    public TokenHandlerInterceptor(UserTokenService userTokenService, UserService userService, WxContext wxContext) {
+        this.userTokenService = userTokenService;
+        this.userService = userService;
+        this.wxContext = wxContext;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String token = request.getHeader("token");
+        if (StringUtils.isEmpty(token)) {
+            RestUtil.response(response, SystemCode.UNAUTHORIZED);
+            return false;
+        }
+
+        if (StringUtils.isBlank(token)) {
+            RestUtil.response(response, SystemCode.UNAUTHORIZED);
+            return false;
+        }
+
+        if (token.length() != 36) {
+            RestUtil.response(response, SystemCode.UNAUTHORIZED);
+            return false;
+        }
+
+        UserToken userToken = userTokenService.getToken(token);
+        if (null == userToken) {
+            RestUtil.response(response, SystemCode.UNAUTHORIZED);
+            return false;
+        }
+
+        Date now = new Date();
+        User user = userService.getUserByUserName(userToken.getUserName());
+        if (now.before(userToken.getEndTime())) {
+            wxContext.setContext(user,userToken);
+            return true;
+        } else {   //refresh token
+            UserToken refreshToken = userTokenService.insertUserToken(user);
+            RestUtil.response(response, SystemCode.AccessTokenError.getCode(), SystemCode.AccessTokenError.getMessage(), refreshToken.getToken());
+            return false;
+        }
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/context/WxContext.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/context/WxContext.java
@@ -1,0 +1,50 @@
+package com.example.genshinstart_backend.context;
+
+import com.example.genshinstart_backend.domain.User;
+import com.example.genshinstart_backend.domain.UserToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+/**
+ * @version 1.1.0
+ * @description: The enum System code.
+ * @author feixia0g
+ * @date 2024/7/9 9:00
+ */
+@Component
+public class WxContext {
+
+    private static final String USER_ATTRIBUTES = "USER_ATTRIBUTES";
+    private static final String USER_TOKEN_ATTRIBUTES = "USER_TOKEN_ATTRIBUTES";
+
+
+    /**
+     * Sets context.
+     *
+     * @param user      the user
+     * @param userToken the user token
+     */
+    public void setContext(User user, UserToken userToken) {
+        RequestContextHolder.currentRequestAttributes().setAttribute(USER_ATTRIBUTES, user, RequestAttributes.SCOPE_REQUEST);
+        RequestContextHolder.currentRequestAttributes().setAttribute(USER_TOKEN_ATTRIBUTES, userToken, RequestAttributes.SCOPE_REQUEST);
+    }
+
+    /**
+     * Gets current user.
+     *
+     * @return the current user
+     */
+    public User getCurrentUser() {
+        return (User) RequestContextHolder.currentRequestAttributes().getAttribute(USER_ATTRIBUTES, RequestAttributes.SCOPE_REQUEST);
+    }
+
+    /**
+     * Gets current user token.
+     *
+     * @return the current user token
+     */
+    public UserToken getCurrentUserToken() {
+        return (UserToken) RequestContextHolder.currentRequestAttributes().getAttribute(USER_TOKEN_ATTRIBUTES, RequestAttributes.SCOPE_REQUEST);
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/BaseWXApiController.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/BaseWXApiController.java
@@ -1,0 +1,22 @@
+package com.example.genshinstart_backend.controller.wx;
+
+import com.example.genshinstart_backend.context.WxContext;
+import com.example.genshinstart_backend.domain.User;
+import com.example.genshinstart_backend.domain.UserToken;
+import com.example.genshinstart_backend.utility.ModelMapperSingle;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class BaseWXApiController {
+    protected final static ModelMapper modelMapper = ModelMapperSingle.Instance();
+    @Autowired
+    private WxContext wxContext;
+
+    protected User getCurrentUser() {
+        return wxContext.getCurrentUser();
+    }
+
+    protected UserToken getUserToken() {
+        return wxContext.getCurrentUserToken();
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/AuthController.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/AuthController.java
@@ -1,0 +1,87 @@
+package com.example.genshinstart_backend.controller.wx.student;
+
+import com.example.genshinstart_backend.base.RestResponse;
+import com.example.genshinstart_backend.configuration.property.SystemConfig;
+import com.example.genshinstart_backend.controller.wx.BaseWXApiController;
+import com.example.genshinstart_backend.domain.User;
+import com.example.genshinstart_backend.domain.UserToken;
+import com.example.genshinstart_backend.domain.enums.UserStatusEnum;
+import com.example.genshinstart_backend.service.AuthenticationService;
+import com.example.genshinstart_backend.service.UserService;
+import com.example.genshinstart_backend.service.UserTokenService;
+import com.example.genshinstart_backend.utility.WxUtil;
+import com.example.genshinstart_backend.viewmodel.wx.student.user.BindInfo;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+
+
+@Controller("WXStudentAuthController")
+@RequestMapping(value = "/api/wx/student/auth")
+@ResponseBody
+public class AuthController extends BaseWXApiController {
+
+    private final SystemConfig systemConfig;
+    private final AuthenticationService authenticationService;
+    private final UserService userService;
+    private final UserTokenService userTokenService;
+
+    @Autowired
+    public AuthController(SystemConfig systemConfig, AuthenticationService authenticationService, UserService userService, UserTokenService userTokenService) {
+        this.systemConfig = systemConfig;
+        this.authenticationService = authenticationService;
+        this.userService = userService;
+        this.userTokenService = userTokenService;
+    }
+
+    @RequestMapping(value = "/bind", method = RequestMethod.POST)
+    public RestResponse bind(@Valid BindInfo model) {
+        User user = userService.getUserByUserName(model.getUserName());
+        if (user == null) {
+            return RestResponse.fail(2, "用户名或密码错误");
+        }
+        boolean result = authenticationService.authUser(user, model.getUserName(), model.getPassword());
+        if (!result) {
+            return RestResponse.fail(2, "用户名或密码错误");
+        }
+        UserStatusEnum userStatusEnum = UserStatusEnum.fromCode(user.getStatus());
+        if (UserStatusEnum.Disable == userStatusEnum) {
+            return RestResponse.fail(3, "用户被禁用");
+        }
+        String code = model.getCode();
+        String openid = WxUtil.getOpenId(systemConfig.getWx().getAppid(), systemConfig.getWx().getSecret(), code);
+        if (null == openid) {
+            return RestResponse.fail(4, "获取微信OpenId失败");
+        }
+        user.setWxOpenId(openid);
+        UserToken userToken = userTokenService.bind(user);
+        return RestResponse.ok(userToken.getToken());
+    }
+
+
+    @RequestMapping(value = "/checkBind", method = RequestMethod.POST)
+    public RestResponse checkBind(@Valid @NotBlank String code) {
+        String openid = WxUtil.getOpenId(systemConfig.getWx().getAppid(), systemConfig.getWx().getSecret(), code);
+        if (null == openid) {
+            return RestResponse.fail(3, "获取微信OpenId失败");
+        }
+        UserToken userToken = userTokenService.checkBind(openid);
+        if (null != userToken) {
+            return RestResponse.ok(userToken.getToken());
+        }
+        return RestResponse.fail(2, "用户未绑定");
+    }
+
+
+    @RequestMapping(value = "/unBind", method = RequestMethod.POST)
+    public RestResponse unBind() {
+        UserToken userToken = getUserToken();
+        userTokenService.unBind(userToken);
+        return RestResponse.ok();
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/DashboardController.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/DashboardController.java
@@ -1,0 +1,129 @@
+package com.example.genshinstart_backend.controller.wx.student;
+
+import com.example.genshinstart_backend.base.RestResponse;
+import com.example.genshinstart_backend.controller.wx.BaseWXApiController;
+import com.example.genshinstart_backend.domain.TaskExam;
+import com.example.genshinstart_backend.domain.TaskExamCustomerAnswer;
+import com.example.genshinstart_backend.domain.TextContent;
+import com.example.genshinstart_backend.domain.User;
+import com.example.genshinstart_backend.domain.enums.ExamPaperTypeEnum;
+import com.example.genshinstart_backend.domain.task.TaskItemAnswerObject;
+import com.example.genshinstart_backend.domain.task.TaskItemObject;
+import com.example.genshinstart_backend.service.ExamPaperService;
+import com.example.genshinstart_backend.service.TaskExamCustomerAnswerService;
+import com.example.genshinstart_backend.service.TaskExamService;
+import com.example.genshinstart_backend.service.TextContentService;
+import com.example.genshinstart_backend.utility.DateTimeUtil;
+import com.example.genshinstart_backend.utility.JsonUtil;
+import com.example.genshinstart_backend.viewmodel.student.dashboard.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Controller("WXStudentDashboardController")
+@RequestMapping(value = "/api/wx/student/dashboard")
+@ResponseBody
+public class DashboardController extends BaseWXApiController {
+
+    private final ExamPaperService examPaperService;
+    private final TextContentService textContentService;
+    private final TaskExamService taskExamService;
+    private final TaskExamCustomerAnswerService taskExamCustomerAnswerService;
+
+    @Autowired
+    public DashboardController(ExamPaperService examPaperService, TextContentService textContentService, TaskExamService taskExamService, TaskExamCustomerAnswerService taskExamCustomerAnswerService) {
+        this.examPaperService = examPaperService;
+        this.textContentService = textContentService;
+        this.taskExamService = taskExamService;
+        this.taskExamCustomerAnswerService = taskExamCustomerAnswerService;
+    }
+
+    @RequestMapping(value = "/index", method = RequestMethod.POST)
+    public RestResponse<IndexVM> index() {
+        IndexVM indexVM = new IndexVM();
+        User user = getCurrentUser();
+
+        PaperFilter fixedPaperFilter = new PaperFilter();
+        fixedPaperFilter.setGradeLevel(user.getUserLevel());
+        fixedPaperFilter.setExamPaperType(ExamPaperTypeEnum.Fixed.getCode());
+        indexVM.setFixedPaper(examPaperService.indexPaper(fixedPaperFilter));
+
+        PaperFilter timeLimitPaperFilter = new PaperFilter();
+        timeLimitPaperFilter.setDateTime(new Date());
+        timeLimitPaperFilter.setGradeLevel(user.getUserLevel());
+        timeLimitPaperFilter.setExamPaperType(ExamPaperTypeEnum.TimeLimit.getCode());
+
+        List<PaperInfo> limitPaper = examPaperService.indexPaper(timeLimitPaperFilter);
+        List<PaperInfoVM> paperInfoVMS = limitPaper.stream().map(d -> {
+            PaperInfoVM vm = modelMapper.map(d, PaperInfoVM.class);
+            vm.setStartTime(DateTimeUtil.dateFormat(d.getLimitStartTime()));
+            vm.setEndTime(DateTimeUtil.dateFormat(d.getLimitEndTime()));
+            return vm;
+        }).collect(Collectors.toList());
+        indexVM.setTimeLimitPaper(paperInfoVMS);
+        return RestResponse.ok(indexVM);
+    }
+
+    @RequestMapping(value = "/task", method = RequestMethod.POST)
+    public RestResponse<List<TaskItemVm>> task() {
+        User user = getCurrentUser();
+        List<TaskExam> taskExams = taskExamService.getByGradeLevel(user.getUserLevel());
+        if (taskExams.size() == 0) {
+            return RestResponse.ok(new ArrayList<>());
+        }
+        List<Integer> tIds = taskExams.stream().map(taskExam -> taskExam.getId()).collect(Collectors.toList());
+        List<TaskExamCustomerAnswer> taskExamCustomerAnswers = taskExamCustomerAnswerService.selectByTUid(tIds, user.getId());
+        List<TaskItemVm> vm = taskExams.stream().map(t -> {
+            TaskItemVm itemVm = new TaskItemVm();
+            itemVm.setId(t.getId());
+            itemVm.setTitle(t.getTitle());
+            TaskExamCustomerAnswer taskExamCustomerAnswer = taskExamCustomerAnswers.stream()
+                    .filter(tc -> tc.getTaskExamId().equals(t.getId())).findFirst().orElse(null);
+            List<TaskItemPaperVm> paperItemVMS = getTaskItemPaperVm(t.getFrameTextContentId(), taskExamCustomerAnswer);
+            itemVm.setPaperItems(paperItemVMS);
+            return itemVm;
+        }).collect(Collectors.toList());
+        return RestResponse.ok(vm);
+    }
+
+
+    private List<TaskItemPaperVm> getTaskItemPaperVm(Integer tFrameId, TaskExamCustomerAnswer taskExamCustomerAnswers) {
+        TextContent textContent = textContentService.selectById(tFrameId);
+        List<TaskItemObject> paperItems = JsonUtil.toJsonListObject(textContent.getContent(), TaskItemObject.class);
+
+        List<TaskItemAnswerObject> answerPaperItems = null;
+        if (null != taskExamCustomerAnswers) {
+            TextContent answerTextContent = textContentService.selectById(taskExamCustomerAnswers.getTextContentId());
+            answerPaperItems = JsonUtil.toJsonListObject(answerTextContent.getContent(), TaskItemAnswerObject.class);
+        }
+
+
+        List<TaskItemAnswerObject> finalAnswerPaperItems = answerPaperItems;
+        return paperItems.stream().map(p -> {
+                    TaskItemPaperVm ivm = new TaskItemPaperVm();
+                    ivm.setExamPaperId(p.getExamPaperId());
+                    ivm.setExamPaperName(p.getExamPaperName());
+                    if (null != finalAnswerPaperItems) {
+                        finalAnswerPaperItems.stream()
+                                .filter(a -> a.getExamPaperId().equals(p.getExamPaperId()))
+                                .findFirst()
+                                .ifPresent(a -> {
+                                    ivm.setExamPaperAnswerId(a.getExamPaperAnswerId());
+                                    ivm.setStatus(a.getStatus());
+                                });
+                    }
+                    return ivm;
+                }
+        ).collect(Collectors.toList());
+    }
+
+
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/ExamPaperAnswerController.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/ExamPaperAnswerController.java
@@ -1,0 +1,135 @@
+package com.example.genshinstart_backend.controller.wx.student;
+
+import com.github.pagehelper.PageInfo;
+import com.example.genshinstart_backend.base.RestResponse;
+import com.example.genshinstart_backend.controller.wx.BaseWXApiController;
+import com.example.genshinstart_backend.domain.*;
+import com.example.genshinstart_backend.domain.enums.QuestionTypeEnum;
+import com.example.genshinstart_backend.event.CalculateExamPaperAnswerCompleteEvent;
+import com.example.genshinstart_backend.event.UserEvent;
+import com.example.genshinstart_backend.service.ExamPaperAnswerService;
+import com.example.genshinstart_backend.service.ExamPaperService;
+import com.example.genshinstart_backend.service.SubjectService;
+import com.example.genshinstart_backend.utility.DateTimeUtil;
+import com.example.genshinstart_backend.utility.ExamUtil;
+import com.example.genshinstart_backend.utility.PageInfoHelper;
+import com.example.genshinstart_backend.viewmodel.admin.exam.ExamPaperEditRequestVM;
+import com.example.genshinstart_backend.viewmodel.student.exam.ExamPaperReadVM;
+import com.example.genshinstart_backend.viewmodel.student.exam.ExamPaperSubmitItemVM;
+import com.example.genshinstart_backend.viewmodel.student.exam.ExamPaperSubmitVM;
+import com.example.genshinstart_backend.viewmodel.student.exampaper.ExamPaperAnswerPageResponseVM;
+import com.example.genshinstart_backend.viewmodel.student.exampaper.ExamPaperAnswerPageVM;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import java.util.*;
+import java.util.stream.Collectors;
+
+
+@Controller("WXStudentExamPaperAnswerController")
+@RequestMapping(value = "/api/wx/student/exampaper/answer")
+@ResponseBody
+public class ExamPaperAnswerController extends BaseWXApiController {
+
+    private final ExamPaperAnswerService examPaperAnswerService;
+    private final SubjectService subjectService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ExamPaperService examPaperService;
+
+    @Autowired
+    public ExamPaperAnswerController(ExamPaperAnswerService examPaperAnswerService, SubjectService subjectService, ApplicationEventPublisher eventPublisher, ExamPaperService examPaperService) {
+        this.examPaperAnswerService = examPaperAnswerService;
+        this.subjectService = subjectService;
+        this.eventPublisher = eventPublisher;
+        this.examPaperService = examPaperService;
+    }
+
+    @RequestMapping(value = "/pageList", method = RequestMethod.POST)
+    public RestResponse<PageInfo<ExamPaperAnswerPageResponseVM>> pageList(@Valid ExamPaperAnswerPageVM model) {
+        model.setCreateUser(getCurrentUser().getId());
+        PageInfo<ExamPaperAnswer> pageInfo = examPaperAnswerService.studentPage(model);
+        PageInfo<ExamPaperAnswerPageResponseVM> page = PageInfoHelper.copyMap(pageInfo, e -> {
+            ExamPaperAnswerPageResponseVM vm = modelMapper.map(e, ExamPaperAnswerPageResponseVM.class);
+            Subject subject = subjectService.selectById(vm.getSubjectId());
+            vm.setDoTime(ExamUtil.secondToVM(e.getDoTime()));
+            vm.setSystemScore(ExamUtil.scoreToVM(e.getSystemScore()));
+            vm.setUserScore(ExamUtil.scoreToVM(e.getUserScore()));
+            vm.setPaperScore(ExamUtil.scoreToVM(e.getPaperScore()));
+            vm.setSubjectName(subject.getName());
+            vm.setCreateTime(DateTimeUtil.dateFormat(e.getCreateTime()));
+            return vm;
+        });
+        return RestResponse.ok(page);
+    }
+
+
+    @RequestMapping(value = "/answerSubmit", method = RequestMethod.POST)
+    public RestResponse answerSubmit(HttpServletRequest request) {
+        ExamPaperSubmitVM examPaperSubmitVM = requestToExamPaperSubmitVM(request);
+        User user = getCurrentUser();
+        ExamPaperAnswerInfo examPaperAnswerInfo = examPaperAnswerService.calculateExamPaperAnswer(examPaperSubmitVM, user);
+        if (null == examPaperAnswerInfo) {
+            return RestResponse.fail(2, "试卷不能重复做");
+        }
+        ExamPaperAnswer examPaperAnswer = examPaperAnswerInfo.getExamPaperAnswer();
+        Integer userScore = examPaperAnswer.getUserScore();
+        String scoreVm = ExamUtil.scoreToVM(userScore);
+        UserEventLog userEventLog = new UserEventLog(user.getId(), user.getUserName(), user.getRealName(), new Date());
+        String content = user.getUserName() + " 提交试卷：" + examPaperAnswerInfo.getExamPaper().getName()
+                + " 得分：" + scoreVm
+                + " 耗时：" + ExamUtil.secondToVM(examPaperAnswer.getDoTime());
+        userEventLog.setContent(content);
+        eventPublisher.publishEvent(new CalculateExamPaperAnswerCompleteEvent(examPaperAnswerInfo));
+        eventPublisher.publishEvent(new UserEvent(userEventLog));
+        return RestResponse.ok(scoreVm);
+    }
+
+    private ExamPaperSubmitVM requestToExamPaperSubmitVM(HttpServletRequest request) {
+        ExamPaperSubmitVM examPaperSubmitVM = new ExamPaperSubmitVM();
+        examPaperSubmitVM.setId(Integer.parseInt(request.getParameter("id")));
+        examPaperSubmitVM.setDoTime(Integer.parseInt(request.getParameter("doTime")));
+        List<String> parameterNames = Collections.list(request.getParameterNames()).stream()
+                .filter(n -> n.contains("_"))
+                .collect(Collectors.toList());
+        //题目答案按序号分组
+        Map<String, List<String>> questionGroup = parameterNames.stream().collect(Collectors.groupingBy(p -> p.substring(0, p.indexOf("_"))));
+        List<ExamPaperSubmitItemVM> answerItems = new ArrayList<>();
+        questionGroup.forEach((k, v) -> {
+            ExamPaperSubmitItemVM examPaperSubmitItemVM = new ExamPaperSubmitItemVM();
+            String p = v.get(0);
+            String[] keys = p.split("_");
+            examPaperSubmitItemVM.setQuestionId(Integer.parseInt(keys[1]));
+            examPaperSubmitItemVM.setItemOrder(Integer.parseInt(keys[0]));
+            QuestionTypeEnum typeEnum = QuestionTypeEnum.fromCode(Integer.parseInt(keys[2]));
+            if (v.size() == 1) {
+                String content = request.getParameter(p);
+                examPaperSubmitItemVM.setContent(content);
+                if (typeEnum == QuestionTypeEnum.MultipleChoice) {
+                    examPaperSubmitItemVM.setContentArray(Arrays.asList(content.split(",")));
+                }
+            } else {  //多个空 填空题
+                List<String> answers = v.stream().sorted(Comparator.comparingInt(ExamUtil::lastNum)).map(inputKey -> request.getParameter(inputKey)).collect(Collectors.toList());
+                examPaperSubmitItemVM.setContentArray(answers);
+            }
+            answerItems.add(examPaperSubmitItemVM);
+        });
+        examPaperSubmitVM.setAnswerItems(answerItems);
+        return examPaperSubmitVM;
+    }
+
+
+    @PostMapping(value = "/read/{id}")
+    public RestResponse<ExamPaperReadVM> read(@PathVariable Integer id) {
+        ExamPaperReadVM vm = new ExamPaperReadVM();
+        ExamPaperAnswer examPaperAnswer = examPaperAnswerService.selectById(id);
+        ExamPaperEditRequestVM paper = examPaperService.examPaperToVM(examPaperAnswer.getExamPaperId());
+        ExamPaperSubmitVM answer = examPaperAnswerService.examPaperAnswerToVM(examPaperAnswer.getId());
+        vm.setPaper(paper);
+        vm.setAnswer(answer);
+        return RestResponse.ok(vm);
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/ExamPaperController.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/ExamPaperController.java
@@ -1,0 +1,59 @@
+package com.example.genshinstart_backend.controller.wx.student;
+
+import com.github.pagehelper.PageInfo;
+import com.example.genshinstart_backend.base.RestResponse;
+import com.example.genshinstart_backend.controller.wx.BaseWXApiController;
+import com.example.genshinstart_backend.domain.ExamPaper;
+import com.example.genshinstart_backend.domain.Subject;
+import com.example.genshinstart_backend.service.ExamPaperService;
+import com.example.genshinstart_backend.service.SubjectService;
+import com.example.genshinstart_backend.utility.DateTimeUtil;
+import com.example.genshinstart_backend.utility.PageInfoHelper;
+import com.example.genshinstart_backend.viewmodel.admin.exam.ExamPaperEditRequestVM;
+import com.example.genshinstart_backend.viewmodel.student.exam.ExamPaperPageResponseVM;
+import com.example.genshinstart_backend.viewmodel.student.exam.ExamPaperPageVM;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.validation.Valid;
+
+@Controller("WXStudentExamController")
+@RequestMapping(value = "/api/wx/student/exampaper")
+@ResponseBody
+public class ExamPaperController extends BaseWXApiController {
+
+    private final ExamPaperService examPaperService;
+    private final SubjectService subjectService;
+
+    @Autowired
+    public ExamPaperController(ExamPaperService examPaperService, SubjectService subjectService) {
+        this.examPaperService = examPaperService;
+        this.subjectService = subjectService;
+    }
+
+
+    @RequestMapping(value = "/select/{id}", method = RequestMethod.POST)
+    public RestResponse<ExamPaperEditRequestVM> select(@PathVariable Integer id) {
+        ExamPaperEditRequestVM vm = examPaperService.examPaperToVM(id);
+        return RestResponse.ok(vm);
+    }
+
+
+    @RequestMapping(value = "/pageList", method = RequestMethod.POST)
+    public RestResponse<PageInfo<ExamPaperPageResponseVM>> pageList(@Valid ExamPaperPageVM model) {
+        model.setLevelId(getCurrentUser().getUserLevel());
+        PageInfo<ExamPaper> pageInfo = examPaperService.studentPage(model);
+        PageInfo<ExamPaperPageResponseVM> page = PageInfoHelper.copyMap(pageInfo, e -> {
+            ExamPaperPageResponseVM vm = modelMapper.map(e, ExamPaperPageResponseVM.class);
+            Subject subject = subjectService.selectById(vm.getSubjectId());
+            vm.setSubjectName(subject.getName());
+            vm.setCreateTime(DateTimeUtil.dateFormat(e.getCreateTime()));
+            return vm;
+        });
+        return RestResponse.ok(page);
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/UserController.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/controller/wx/student/UserController.java
@@ -1,0 +1,151 @@
+package com.example.genshinstart_backend.controller.wx.student;
+
+import com.github.pagehelper.PageInfo;
+import com.example.genshinstart_backend.base.RestResponse;
+import com.example.genshinstart_backend.controller.wx.BaseWXApiController;
+import com.example.genshinstart_backend.domain.Message;
+import com.example.genshinstart_backend.domain.MessageUser;
+import com.example.genshinstart_backend.domain.User;
+import com.example.genshinstart_backend.domain.UserEventLog;
+import com.example.genshinstart_backend.domain.enums.RoleEnum;
+import com.example.genshinstart_backend.domain.enums.UserStatusEnum;
+import com.example.genshinstart_backend.event.UserEvent;
+import com.example.genshinstart_backend.service.AuthenticationService;
+import com.example.genshinstart_backend.service.MessageService;
+import com.example.genshinstart_backend.service.UserEventLogService;
+import com.example.genshinstart_backend.service.UserService;
+import com.example.genshinstart_backend.utility.DateTimeUtil;
+import com.example.genshinstart_backend.utility.PageInfoHelper;
+import com.example.genshinstart_backend.viewmodel.student.user.*;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import javax.validation.Valid;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Controller("WXStudentUserController")
+@RequestMapping(value = "/api/wx/student/user")
+@ResponseBody
+public class UserController extends BaseWXApiController {
+
+    private final UserService userService;
+    private final UserEventLogService userEventLogService;
+    private final MessageService messageService;
+    private final AuthenticationService authenticationService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    public UserController(UserService userService, UserEventLogService userEventLogService, MessageService messageService, AuthenticationService authenticationService, ApplicationEventPublisher eventPublisher) {
+        this.userService = userService;
+        this.userEventLogService = userEventLogService;
+        this.messageService = messageService;
+        this.authenticationService = authenticationService;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @RequestMapping(value = "/current", method = RequestMethod.POST)
+    public RestResponse<UserResponseVM> current() {
+        User user = getCurrentUser();
+        UserResponseVM userVm = UserResponseVM.from(user);
+        userVm.setBirthDay(DateTimeUtil.dateShortFormat(user.getBirthDay()));
+        return RestResponse.ok(userVm);
+    }
+
+    @RequestMapping(value = "/register", method = RequestMethod.POST)
+    public RestResponse register(@Valid UserRegisterVM model) {
+        User existUser = userService.getUserByUserName(model.getUserName());
+        if (null != existUser) {
+            return new RestResponse<>(2, "用户已存在");
+        }
+        User user = modelMapper.map(model, User.class);
+        String encodePwd = authenticationService.pwdEncode(model.getPassword());
+        user.setUserUuid(UUID.randomUUID().toString());
+        user.setPassword(encodePwd);
+        user.setRole(RoleEnum.STUDENT.getCode());
+        user.setStatus(UserStatusEnum.Enable.getCode());
+        user.setLastActiveTime(new Date());
+        user.setCreateTime(new Date());
+        user.setDeleted(false);
+        userService.insertByFilter(user);
+        UserEventLog userEventLog = new UserEventLog(user.getId(), user.getUserName(), user.getRealName(), new Date());
+        userEventLog.setContent("欢迎 " + user.getUserName() + " 注册来到学之思开源考试系统");
+        eventPublisher.publishEvent(new UserEvent(userEventLog));
+        return RestResponse.ok();
+    }
+
+    @RequestMapping(value = "/update", method = RequestMethod.POST)
+    public RestResponse<UserResponseVM> update(@Valid UserUpdateVM model) {
+        if (StringUtils.isBlank(model.getBirthDay())) {
+            model.setBirthDay(null);
+        }
+        User user = userService.selectById(getCurrentUser().getId());
+        modelMapper.map(model, user);
+        user.setModifyTime(new Date());
+        userService.updateByIdFilter(user);
+        UserEventLog userEventLog = new UserEventLog(user.getId(), user.getUserName(), user.getRealName(), new Date());
+        userEventLog.setContent(user.getUserName() + " 更新了个人资料");
+        eventPublisher.publishEvent(new UserEvent(userEventLog));
+        UserResponseVM userVm = UserResponseVM.from(user);
+        return RestResponse.ok(userVm);
+    }
+
+    @RequestMapping(value = "/log", method = RequestMethod.POST)
+    public RestResponse<List<UserEventLogVM>> log() {
+        User user = getCurrentUser();
+        List<UserEventLog> userEventLogs = userEventLogService.getUserEventLogByUserId(user.getId());
+        List<UserEventLogVM> userEventLogVMS = userEventLogs.stream().map(d -> {
+            UserEventLogVM vm = modelMapper.map(d, UserEventLogVM.class);
+            vm.setCreateTime(DateTimeUtil.dateFormat(d.getCreateTime()));
+            return vm;
+        }).collect(Collectors.toList());
+        return RestResponse.ok(userEventLogVMS);
+    }
+
+    @RequestMapping(value = "/message/page", method = RequestMethod.POST)
+    public RestResponse<PageInfo<MessageResponseVM>> messagePageList(MessageRequestVM messageRequestVM) {
+        messageRequestVM.setReceiveUserId(getCurrentUser().getId());
+        PageInfo<MessageUser> messageUserPageInfo = messageService.studentPage(messageRequestVM);
+        List<Integer> ids = messageUserPageInfo.getList().stream().map(d -> d.getMessageId()).collect(Collectors.toList());
+        List<Message> messages = ids.size() != 0 ? messageService.selectMessageByIds(ids) : null;
+        PageInfo<MessageResponseVM> page = PageInfoHelper.copyMap(messageUserPageInfo, e -> {
+            MessageResponseVM vm = modelMapper.map(e, MessageResponseVM.class);
+            messages.stream().filter(d -> e.getMessageId().equals(d.getId())).findFirst().ifPresent(message -> {
+                vm.setTitle(message.getTitle());
+                vm.setContent(message.getContent());
+                vm.setSendUserName(message.getSendUserName());
+            });
+            vm.setCreateTime(DateTimeUtil.dateFormat(e.getCreateTime()));
+            return vm;
+        });
+        return RestResponse.ok(page);
+    }
+
+    @RequestMapping(value = "/message/detail/{id}", method = RequestMethod.POST)
+    public RestResponse messageDetail(@PathVariable Integer id) {
+        Message message = messageService.messageDetail(id);
+        return RestResponse.ok(message);
+    }
+
+
+    @RequestMapping(value = "/message/unreadCount", method = RequestMethod.POST)
+    public RestResponse unReadCount() {
+        Integer count = messageService.unReadCount(getCurrentUser().getId());
+        return RestResponse.ok(count);
+    }
+
+    @RequestMapping(value = "/message/read/{id}", method = RequestMethod.POST)
+    public RestResponse read(@PathVariable Integer id) {
+        messageService.read(id);
+        return RestResponse.ok();
+    }
+
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/domain/UserToken.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/domain/UserToken.java
@@ -1,0 +1,97 @@
+package com.example.genshinstart_backend.domain;
+
+import java.io.Serializable;
+import java.util.Date;
+
+public class UserToken implements Serializable {
+
+    private static final long serialVersionUID = -2414443061696200360L;
+
+    private Integer id;
+
+    /**
+     * 用户token
+     */
+    private String token;
+
+    /**
+     * 用户Id
+     */
+    private Integer userId;
+
+    /**
+     * 微信小程序openId
+     */
+    private String wxOpenId;
+
+    /**
+     * 创建时间
+     */
+    private Date createTime;
+
+    /**
+     * 结束时间
+     */
+    private Date endTime;
+
+    /**
+     * 用户名
+     */
+    private String userName;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token == null ? null : token.trim();
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Integer userId) {
+        this.userId = userId;
+    }
+
+    public String getWxOpenId() {
+        return wxOpenId;
+    }
+
+    public void setWxOpenId(String wxOpenId) {
+        this.wxOpenId = wxOpenId == null ? null : wxOpenId.trim();
+    }
+
+    public Date getCreateTime() {
+        return createTime;
+    }
+
+    public void setCreateTime(Date createTime) {
+        this.createTime = createTime;
+    }
+
+    public Date getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Date endTime) {
+        this.endTime = endTime;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName == null ? null : userName.trim();
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/listener/CalculateExamPaperAnswerListener.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/listener/CalculateExamPaperAnswerListener.java
@@ -1,0 +1,81 @@
+package com.example.genshinstart_backend.listener;
+
+import com.example.genshinstart_backend.domain.*;
+import com.example.genshinstart_backend.domain.enums.ExamPaperTypeEnum;
+import com.example.genshinstart_backend.domain.enums.QuestionTypeEnum;
+import com.example.genshinstart_backend.event.CalculateExamPaperAnswerCompleteEvent;
+import com.example.genshinstart_backend.service.ExamPaperAnswerService;
+import com.example.genshinstart_backend.service.ExamPaperQuestionCustomerAnswerService;
+import com.example.genshinstart_backend.service.TaskExamCustomerAnswerService;
+import com.example.genshinstart_backend.service.TextContentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.List;
+
+
+/**
+ * @version 1.1.0
+ * @description: The type Calculate exam paper answer listener.
+ * @author kodi
+ * @date 2024/7/9 14:30
+ */
+@Component
+public class CalculateExamPaperAnswerListener implements ApplicationListener<CalculateExamPaperAnswerCompleteEvent> {
+
+    private final ExamPaperAnswerService examPaperAnswerService;
+    private final ExamPaperQuestionCustomerAnswerService examPaperQuestionCustomerAnswerService;
+    private final TextContentService textContentService;
+    private final TaskExamCustomerAnswerService examCustomerAnswerService;
+
+    /**
+     * Instantiates a new Calculate exam paper answer listener.
+     *
+     * @param examPaperAnswerService                 the exam paper answer service
+     * @param examPaperQuestionCustomerAnswerService the exam paper question customer answer service
+     * @param textContentService                     the text content service
+     * @param examCustomerAnswerService              the exam customer answer service
+     */
+    @Autowired
+    public CalculateExamPaperAnswerListener(ExamPaperAnswerService examPaperAnswerService, ExamPaperQuestionCustomerAnswerService examPaperQuestionCustomerAnswerService, TextContentService textContentService, TaskExamCustomerAnswerService examCustomerAnswerService) {
+        this.examPaperAnswerService = examPaperAnswerService;
+        this.examPaperQuestionCustomerAnswerService = examPaperQuestionCustomerAnswerService;
+        this.textContentService = textContentService;
+        this.examCustomerAnswerService = examCustomerAnswerService;
+    }
+
+    @Override
+    @Transactional
+    public void onApplicationEvent(CalculateExamPaperAnswerCompleteEvent calculateExamPaperAnswerCompleteEvent) {
+        Date now = new Date();
+
+        ExamPaperAnswerInfo examPaperAnswerInfo = (ExamPaperAnswerInfo) calculateExamPaperAnswerCompleteEvent.getSource();
+        ExamPaper examPaper = examPaperAnswerInfo.getExamPaper();
+        ExamPaperAnswer examPaperAnswer = examPaperAnswerInfo.getExamPaperAnswer();
+        List<ExamPaperQuestionCustomerAnswer> examPaperQuestionCustomerAnswers = examPaperAnswerInfo.getExamPaperQuestionCustomerAnswers();
+
+        examPaperAnswerService.insertByFilter(examPaperAnswer);
+        examPaperQuestionCustomerAnswers.stream().filter(a -> QuestionTypeEnum.needSaveTextContent(a.getQuestionType())).forEach(d -> {
+            TextContent textContent = new TextContent(d.getAnswer(), now);
+            textContentService.insertByFilter(textContent);
+            d.setTextContentId(textContent.getId());
+            d.setAnswer(null);
+        });
+        examPaperQuestionCustomerAnswers.forEach(d -> {
+            d.setExamPaperAnswerId(examPaperAnswer.getId());
+        });
+        examPaperQuestionCustomerAnswerService.insertList(examPaperQuestionCustomerAnswers);
+
+        switch (ExamPaperTypeEnum.fromCode(examPaper.getPaperType())) {
+            case Task: {
+                examCustomerAnswerService.insertOrUpdate(examPaper, examPaperAnswer, now);
+                break;
+            }
+            default:
+                break;
+        }
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/listener/EmailSendListener.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/listener/EmailSendListener.java
@@ -1,0 +1,25 @@
+package com.example.genshinstart_backend.listener;
+
+import com.example.genshinstart_backend.domain.User;
+import com.example.genshinstart_backend.event.OnRegistrationCompleteEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * @version 1.1.0
+ * @description: The type Email send listener.
+ * @author kodi
+ * @date 2024/7/9 14:30
+ */
+@Component
+public class EmailSendListener implements ApplicationListener<OnRegistrationCompleteEvent> {
+
+    @Override
+    @NonNull
+    public void onApplicationEvent(OnRegistrationCompleteEvent event) {
+        User user = event.getUser();
+        System.out.println("User register Email sender :" + user.getUserName());
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/listener/UserLogListener.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/listener/UserLogListener.java
@@ -1,0 +1,35 @@
+package com.example.genshinstart_backend.listener;
+
+import com.example.genshinstart_backend.event.UserEvent;
+import com.example.genshinstart_backend.service.UserEventLogService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * @version 1.1.0
+ * @description: The type User log listener.
+ * @author kodi
+ * @date 2024/7/9 14:30
+ */
+@Component
+public class UserLogListener implements ApplicationListener<UserEvent> {
+
+    private final UserEventLogService userEventLogService;
+
+    /**
+     * Instantiates a new User log listener.
+     *
+     * @param userEventLogService the user event log service
+     */
+    @Autowired
+    public UserLogListener(UserEventLogService userEventLogService) {
+        this.userEventLogService = userEventLogService;
+    }
+
+    @Override
+    public void onApplicationEvent(UserEvent userEvent) {
+        userEventLogService.insertByFilter(userEvent.getUserEventLog());
+    }
+
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/repository/UserTokenMapper.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/repository/UserTokenMapper.java
@@ -1,0 +1,11 @@
+package com.example.genshinstart_backend.repository;
+
+import com.example.genshinstart_backend.domain.UserToken;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UserTokenMapper extends BaseMapper<UserToken> {
+
+    UserToken getToken(String token);
+
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/service/UserTokenService.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/service/UserTokenService.java
@@ -1,0 +1,46 @@
+package com.example.genshinstart_backend.service;
+
+import com.example.genshinstart_backend.domain.User;
+import com.example.genshinstart_backend.domain.UserToken;
+
+public interface UserTokenService extends BaseService<UserToken> {
+
+    /**
+     * 微信token绑定
+     *
+     * @param user user
+     * @return UserToken
+     */
+    UserToken bind(User user);
+
+    /**
+     * 检查微信openId是否绑定过
+     *
+     * @param openId openId
+     * @return UserToken
+     */
+    UserToken checkBind(String openId);
+
+    /**
+     * 根据token获取UserToken，带缓存的
+     *
+     * @param token token
+     * @return UserToken
+     */
+    UserToken getToken(String token);
+
+    /**
+     * 插入用户Token
+     *
+     * @param user user
+     * @return UserToken
+     */
+    UserToken insertUserToken(User user);
+
+    /**
+     * 微信小程序退出，清除缓存
+     *
+     * @param userToken userToken
+     */
+    void unBind(UserToken userToken);
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/service/impl/UserTokenServiceImpl.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/service/impl/UserTokenServiceImpl.java
@@ -1,0 +1,81 @@
+package com.example.genshinstart_backend.service.impl;
+
+import com.example.genshinstart_backend.configuration.property.SystemConfig;
+import com.example.genshinstart_backend.domain.User;
+import com.example.genshinstart_backend.domain.UserToken;
+import com.example.genshinstart_backend.repository.UserTokenMapper;
+import com.example.genshinstart_backend.service.UserService;
+import com.example.genshinstart_backend.service.UserTokenService;
+import com.example.genshinstart_backend.utility.DateTimeUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Service
+public class UserTokenServiceImpl extends BaseServiceImpl<UserToken> implements UserTokenService {
+
+    private final UserTokenMapper userTokenMapper;
+    private final UserService userService;
+    private final SystemConfig systemConfig;
+
+    @Autowired
+    public UserTokenServiceImpl(UserTokenMapper userTokenMapper, UserService userService, SystemConfig systemConfig) {
+        super(userTokenMapper);
+        this.userTokenMapper = userTokenMapper;
+        this.userService = userService;
+        this.systemConfig = systemConfig;
+    }
+
+
+    @Override
+    @Transactional
+    public UserToken bind(User user) {
+        user.setModifyTime(new Date());
+        userService.updateByIdFilter(user);
+        return insertUserToken(user);
+    }
+
+
+    @Override
+    public UserToken checkBind(String openId) {
+        User user = userService.selectByWxOpenId(openId);
+        if (null != user) {
+            return insertUserToken(user);
+        }
+        return null;
+    }
+
+    @Override
+    public UserToken getToken(String token) {
+        return userTokenMapper.getToken(token);
+    }
+
+    @Override
+    public UserToken insertUserToken(User user) {
+        Date startTime = new Date();
+        Date endTime = DateTimeUtil.addDuration(startTime, systemConfig.getWx().getTokenToLive());
+        UserToken userToken = new UserToken();
+        userToken.setToken(UUID.randomUUID().toString());
+        userToken.setUserId(user.getId());
+        userToken.setWxOpenId(user.getWxOpenId());
+        userToken.setCreateTime(startTime);
+        userToken.setEndTime(endTime);
+        userToken.setUserName(user.getUserName());
+        userService.updateByIdFilter(user);
+        userTokenMapper.insertSelective(userToken);
+        return userToken;
+    }
+
+    @Override
+    public void unBind(UserToken userToken) {
+        User user = userService.selectById(userToken.getUserId());
+        user.setModifyTime(new Date());
+        user.setWxOpenId(null);
+        userService.updateById(user);
+        userTokenMapper.deleteByPrimaryKey(userToken.getId());
+    }
+
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/utility/WxResponse.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/utility/WxResponse.java
@@ -1,0 +1,62 @@
+package com.example.genshinstart_backend.utility;
+
+
+import java.io.Serializable;
+
+
+/**
+ * @version 1.1.0
+ * @description: The type Wx response.
+ * @author kodi
+ * @date 2024/7/11 13:30
+ */
+public class WxResponse implements Serializable {
+    private static final long serialVersionUID = -8496869159673561976L;
+    private String session_key;
+    private String openid;
+
+    /**
+     * Gets serial version uid.
+     *
+     * @return the serial version uid
+     */
+    public static long getSerialVersionUID() {
+        return serialVersionUID;
+    }
+
+    /**
+     * Gets session key.
+     *
+     * @return the session key
+     */
+    public String getSession_key() {
+        return session_key;
+    }
+
+    /**
+     * Sets session key.
+     *
+     * @param session_key the session key
+     */
+    public void setSession_key(String session_key) {
+        this.session_key = session_key;
+    }
+
+    /**
+     * Gets openid.
+     *
+     * @return the openid
+     */
+    public String getOpenid() {
+        return openid;
+    }
+
+    /**
+     * Sets openid.
+     *
+     * @param openid the openid
+     */
+    public void setOpenid(String openid) {
+        this.openid = openid;
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/utility/WxUtil.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/utility/WxUtil.java
@@ -1,0 +1,49 @@
+package com.example.genshinstart_backend.utility;
+
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+/**
+ * @version 1.1.0
+ * @description: The type Wx util.
+ * @author kodi
+ * @date 2024/7/11 13:35
+ */
+public class WxUtil {
+    private static final Logger logger = LoggerFactory.getLogger(WxUtil.class);
+    private static final String openIdUrl = "https://api.weixin.qq.com/sns/jscode2session?appid=%s&secret=%s&js_code=%s&grant_type=authorization_code";
+
+    /**
+     * Gets open id.
+     *
+     * @param appId  the app id
+     * @param secret the secret
+     * @param code   the code
+     * @return the open id
+     */
+    public static String getOpenId(String appId, String secret, String code) {
+        try (CloseableHttpClient httpClient = HttpClientBuilder.create().build()) {
+            String requestUrl = String.format(openIdUrl, appId, secret, code);
+            HttpGet httpGet = new HttpGet(requestUrl);
+            HttpEntity responseEntity = httpClient.execute(httpGet).getEntity();
+            if (responseEntity != null) {
+                String responseStr = EntityUtils.toString(responseEntity);
+                if (responseStr.contains("openid")) {
+                    WxResponse wxResponse = JsonUtil.toJsonObject(responseStr, WxResponse.class);
+                    return wxResponse.getOpenid();
+                }
+            }
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+        }
+        return null;
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/viewmodel/user/BindInfo.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/viewmodel/user/BindInfo.java
@@ -1,0 +1,40 @@
+package com.example.genshinstart_backend.viewmodel.user;
+
+
+import javax.validation.constraints.NotBlank;
+
+public class BindInfo {
+
+    @NotBlank
+    private String userName;
+
+    @NotBlank
+    private String password;
+
+    @NotBlank
+    private String code;
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/viewmodel/wx/student/user/BindInfo.java
+++ b/GenshinStart_backend/src/main/java/com/example/genshinstart_backend/viewmodel/wx/student/user/BindInfo.java
@@ -1,4 +1,4 @@
-package com.example.genshinstart_backend.viewmodel.user;
+package com.example.genshinstart_backend.viewmodel.wx.student.user;
 
 
 import javax.validation.constraints.NotBlank;

--- a/GenshinStart_backend/src/main/resources/application.yml
+++ b/GenshinStart_backend/src/main/resources/application.yml
@@ -24,6 +24,14 @@ system:
   pwdKey:
     publicKey: MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQClwwxhJKwStDnu7c0yCRkwTW2VKuLWwyVtFC6Zx9bYdF1qwqSP26CkDwaF6GHayIvv9b8BHlAaQH4SLIPzir062yzNukqspmthUw4gPJhbx1AQrWRoQJSv3/1Sk+tWyJRHXSiCZJZ3216LDhtx42LQ0HItDP8U9BLtsxA+5LEZzQIDAQAB
     privateKey: MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAKXDDGEkrBK0Oe7tzTIJGTBNbZUq4tbDJW0ULpnH1th0XWrCpI/boKQPBoXoYdrIi+/1vwEeUBpAfhIsg/OKvTrbLM26Sqyma2FTDiA8mFvHUBCtZGhAlK/f/VKT61bIlEddKIJklnfbXosOG3HjYtDQci0M/xT0Eu2zED7ksRnNAgMBAAECgYEAlCuz5yn2volnt9HNuEo1v92WdN5vAnZSAB0oQsJFpBrwXjw7CXTTNZNQy2YcAot9uzO6Vu+Xvr+jce9ky9BasM7ehz0gnwJWAO79IqUnmu3RRq7HllDwp72qysXIypJZCF4HX5jAzUGlNzlTSUb1H4LtavKc6a//YqPfQ0jTLsECQQDZuGKGAYq6rBCX0+T8qlQpCPc41wsl4Gi9lLD21ks9PMx44JdhsUrqLWItZiGynDzq1LJ3M1hr3gbSsPQcI9HJAkEAwugDFCiRLOqOBRRGlYbzgGdmXbR4SrMNIpcFTFhU+MsEqaMueVPiNtRSIK6W8pS28ZN0aiZDTBAT84fOIENp5QJBAJaVgQ9OYbVa7N8WH3riE/ONz+/wTDWWUNtOzFbtQHzKYGH6dLmM9lOhsBXWXdg7V6bUFdt8F9wDZJS07yHHZIECQG4rHrJiS80Lt8L/NvaGFVVbHO2SePwgQShwHLqOo1kNyFDqv/YsiA1d7h4zEXeEv/PE2WS2xAtWezCIbualtFECQQDPUkYhs3vZoZgsltdeFnv/WoXaXNRIzunMTmksIlh8JP7C1xQHrwdCpUkffgSVphxGJGHkxooMpki7oTC1Mdjx
+  wx:
+    appid: wxfcea70cd640d9a17
+    secret: 5bcea7342dc5597be1b634518ede4015
+    token-to-live: 12h   #token 过期时间
+    security-ignore-urls:
+      - /api/wx/student/auth/bind
+      - /api/wx/student/auth/checkBind
+      - /api/wx/student/user/register
   qn:
     url: http://sg34whmva.hd-bkt.clouddn.com
     bucket: genshinstart

--- a/GenshinStart_backend/src/main/resources/mapper/UserTokenMapper.xml
+++ b/GenshinStart_backend/src/main/resources/mapper/UserTokenMapper.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.genshinstart_backend.repository.UserTokenMapper">
+  <resultMap id="BaseResultMap" type="com.example.genshinstart_backend.domain.UserToken">
+    <id column="id" jdbcType="INTEGER" property="id" />
+    <result column="token" jdbcType="VARCHAR" property="token" />
+    <result column="user_id" jdbcType="INTEGER" property="userId" />
+    <result column="wx_open_id" jdbcType="VARCHAR" property="wxOpenId" />
+    <result column="create_time" jdbcType="TIMESTAMP" property="createTime" />
+    <result column="end_time" jdbcType="TIMESTAMP" property="endTime" />
+    <result column="user_name" jdbcType="VARCHAR" property="userName" />
+  </resultMap>
+  <sql id="Base_Column_List">
+    id, token, user_id, wx_open_id, create_time, end_time, user_name
+  </sql>
+  <select id="selectByPrimaryKey" parameterType="java.lang.Integer" resultMap="BaseResultMap">
+    select
+    <include refid="Base_Column_List" />
+    from t_user_token
+    where id = #{id,jdbcType=INTEGER}
+  </select>
+  <delete id="deleteByPrimaryKey" parameterType="java.lang.Integer">
+    delete from t_user_token
+    where id = #{id,jdbcType=INTEGER}
+  </delete>
+  <insert id="insert" parameterType="com.example.genshinstart_backend.domain.UserToken" useGeneratedKeys="true" keyProperty="id">
+    insert into t_user_token (id, token, user_id,
+      wx_open_id, create_time, end_time,
+      user_name)
+    values (#{id,jdbcType=INTEGER}, #{token,jdbcType=VARCHAR}, #{userId,jdbcType=INTEGER},
+      #{wxOpenId,jdbcType=VARCHAR}, #{createTime,jdbcType=TIMESTAMP}, #{endTime,jdbcType=TIMESTAMP},
+      #{userName,jdbcType=VARCHAR})
+  </insert>
+  <insert id="insertSelective" parameterType="com.example.genshinstart_backend.domain.UserToken" useGeneratedKeys="true" keyProperty="id">
+    insert into t_user_token
+    <trim prefix="(" suffix=")" suffixOverrides=",">
+      <if test="id != null">
+        id,
+      </if>
+      <if test="token != null">
+        token,
+      </if>
+      <if test="userId != null">
+        user_id,
+      </if>
+      <if test="wxOpenId != null">
+        wx_open_id,
+      </if>
+      <if test="createTime != null">
+        create_time,
+      </if>
+      <if test="endTime != null">
+        end_time,
+      </if>
+      <if test="userName != null">
+        user_name,
+      </if>
+    </trim>
+    <trim prefix="values (" suffix=")" suffixOverrides=",">
+      <if test="id != null">
+        #{id,jdbcType=INTEGER},
+      </if>
+      <if test="token != null">
+        #{token,jdbcType=VARCHAR},
+      </if>
+      <if test="userId != null">
+        #{userId,jdbcType=INTEGER},
+      </if>
+      <if test="wxOpenId != null">
+        #{wxOpenId,jdbcType=VARCHAR},
+      </if>
+      <if test="createTime != null">
+        #{createTime,jdbcType=TIMESTAMP},
+      </if>
+      <if test="endTime != null">
+        #{endTime,jdbcType=TIMESTAMP},
+      </if>
+      <if test="userName != null">
+        #{userName,jdbcType=VARCHAR},
+      </if>
+    </trim>
+  </insert>
+  <update id="updateByPrimaryKeySelective" parameterType="com.example.genshinstart_backend.domain.UserToken">
+    update t_user_token
+    <set>
+      <if test="token != null">
+        token = #{token,jdbcType=VARCHAR},
+      </if>
+      <if test="userId != null">
+        user_id = #{userId,jdbcType=INTEGER},
+      </if>
+      <if test="wxOpenId != null">
+        wx_open_id = #{wxOpenId,jdbcType=VARCHAR},
+      </if>
+      <if test="createTime != null">
+        create_time = #{createTime,jdbcType=TIMESTAMP},
+      </if>
+      <if test="endTime != null">
+        end_time = #{endTime,jdbcType=TIMESTAMP},
+      </if>
+      <if test="userName != null">
+        user_name = #{userName,jdbcType=VARCHAR},
+      </if>
+    </set>
+    where id = #{id,jdbcType=INTEGER}
+  </update>
+  <update id="updateByPrimaryKey" parameterType="com.example.genshinstart_backend.domain.UserToken">
+    update t_user_token
+    set token = #{token,jdbcType=VARCHAR},
+      user_id = #{userId,jdbcType=INTEGER},
+      wx_open_id = #{wxOpenId,jdbcType=VARCHAR},
+      create_time = #{createTime,jdbcType=TIMESTAMP},
+      end_time = #{endTime,jdbcType=TIMESTAMP},
+      user_name = #{userName,jdbcType=VARCHAR}
+    where id = #{id,jdbcType=INTEGER}
+  </update>
+  <select id="getToken" parameterType="java.lang.String" resultMap="BaseResultMap">
+    select
+    <include refid="Base_Column_List" />
+    from t_user_token
+    where token = #{token,jdbcType=VARCHAR}
+    order by id desc
+    limit 1
+  </select>
+</mapper>


### PR DESCRIPTION
### 基本描述
实现微信端学生端所有接口

### 变更内容
* 添加微信相关配置信息以及配置类
* 添加微信用户类UserToken以及对应的Service和Mapper层
* 添加WxContext和TokenHandlerInterceptor
* 添加WxResponse/WxUtil/WxResponse
* 添加BaseWxAPIController基类并实现UserController各个接口功能
* 实现DashboardController各个接口功能
* 实现AuthController各个接口功能
* 实现ExamPaperController各个接口功能
* 实现ExamPaperAnswerController各个接口功能
* 添加listener目录下CalculateExamPaperAnswerListener/EmailSendListener/UserLogListener

#12 